### PR TITLE
add gpg key to avoid unsigned error which prevented build

### DIFF
--- a/edge-logic/Dockerfile.template
+++ b/edge-logic/Dockerfile.template
@@ -1,6 +1,8 @@
 # Built using https://coral.withgoogle.com/tutorials/accelerator/
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
 
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
 # Install python3
 RUN install_packages python3-pip
 

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: generic


### PR DESCRIPTION
per [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install)

closes #2 